### PR TITLE
Use rand 0.4.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 byteorder     = "1.0"
-rand          = "0.3"
+rand          = "0.4"
 futures       = "0.1.14"
 tokio-core    = "0.1.9"
 


### PR DESCRIPTION
Use rand 0.4 so that other projects that already depend on rand 0.4
don't have to compile rand multiple times.

Contributed on behalf of Buoyant, Inc.

Signed-off-by: Brian Smith <brian@briansmith.org>