### PR TITLE
Fix error encountered when parsing TXT records

### DIFF
--- a/src/rdata/rfc1035.rs
+++ b/src/rdata/rfc1035.rs
@@ -725,7 +725,7 @@ impl<'a> Txt<&'a [u8]> {
         let bytes = try!(parser.parse_bytes(len));
         let mut tmp = bytes;
         while !tmp.is_empty() {
-            let len = tmp[0] as usize;
+            let len = (tmp[0] as usize) + 1;
             if len > tmp.len() {
                 return Err(ParseError::FormErr)
             }


### PR DESCRIPTION
Hi,
Domain currently fails with a `FormErr` anytime I try to query TXT records for a hostname. Removing this section fixes the problem and results in correctly parsed TXT records. I'm not sure the intent of the block of code or if it is important, but in the tests I've run I haven't encountered any issues after removing it.